### PR TITLE
Remove Mailchimp API

### DIFF
--- a/admin/class-admin-ajax.php
+++ b/admin/class-admin-ajax.php
@@ -1030,7 +1030,7 @@ if ( ! class_exists( 'WMobilePack_Admin_Ajax' ) ) {
          */
         public function settings_waitlist()
         {
-
+            /*
             if (current_user_can('manage_options')) {
 
                 $status = 0;
@@ -1104,6 +1104,7 @@ if ( ! class_exists( 'WMobilePack_Admin_Ajax' ) ) {
 
                 echo $status;
             }
+            */
 
             exit();
         }

--- a/admin/sections/subscribe.php
+++ b/admin/sections/subscribe.php
@@ -16,48 +16,48 @@ $is_secure = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || $_SER
 		<div class="spacer-10"></div>
 		<p>Sign up and get FREE mobile growth lessons:</p>
 		<div class="spacer-10"></div>
-    <!-- Begin Mailchimp Signup Form -->
-<link href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css" rel="stylesheet" type="text/css">
-<style type="text/css">
-	#mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; }
-  #mc_embed_signup .clear {width:96%;}
-  #mc_embed_signup h2 {width:96%;}
-	/* Add your own Mailchimp form style overrides in your site stylesheet or in this style block.
-	   We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
-</style>
-<div id="mc_embed_signup">
-<form action="https://wpmobilepack.us13.list-manage.com/subscribe/post?u=df15f7f3ba7071146f98e66b3&amp;id=6989f14b64" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<h2>Subscribe</h2>
-<div class="indicates-required"><span class="asterisk">*</span> indicates required</div>
-<div class="mc-field-group">
-	<label for="mce-EMAIL">Email Address  <span class="asterisk">*</span>
-</label>
-	<input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" style="margin:auto;">
-</div>
-<div class="mc-field-group">
-	<label for="mce-FNAME">First Name </label>
-	<input type="text" value="" name="FNAME" class="" id="mce-FNAME" style="margin:auto;">
-</div>
-<div class="mc-field-group">
-	<label for="mce-LNAME">Last Name </label>
-	<input type="text" value="" name="LNAME" class="" id="mce-LNAME" style="margin:auto;">
-</div>
-<div class="mc-field-group">
-	<label for="mce-MMERGE5">Business </label>
-	<input type="text" value="" name="MMERGE5" class="" id="mce-MMERGE5" style="margin:auto;">
-</div>
-	<div id="mce-responses" class="clear">
-		<div class="response" id="mce-error-response" style="display:none"></div>
-		<div class="response" id="mce-success-response" style="display:none"></div>
-	</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_df15f7f3ba7071146f98e66b3_6989f14b64" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
-<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[3]='ADDRESS';ftypes[3]='address';fnames[4]='PHONE';ftypes[4]='phone';fnames[5]='MMERGE5';ftypes[5]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
-<!--End mc_embed_signup-->
+		<!-- Begin Mailchimp Signup Form -->
+		<link href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css" rel="stylesheet" type="text/css">
+		<style type="text/css">
+			#mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; }
+			#mc_embed_signup .clear {width:96%;}
+			#mc_embed_signup h2 {width:96%;}
+			/* Add your own Mailchimp form style overrides in your site stylesheet or in this style block.
+				We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
+		</style>
+		<div id="mc_embed_signup">
+			<form action="https://wpmobilepack.us13.list-manage.com/subscribe/post?u=df15f7f3ba7071146f98e66b3&amp;id=6989f14b64" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+				<div id="mc_embed_signup_scroll">
+					<h2>Subscribe</h2>
+					<div class="indicates-required"><span class="asterisk">*</span> indicates required</div>
+					<div class="mc-field-group">
+						<label for="mce-EMAIL">Email Address  <span class="asterisk">*</span>
+						</label>
+						<input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" style="margin:auto;">
+					</div>
+					<div class="mc-field-group">
+						<label for="mce-FNAME">First Name </label>
+						<input type="text" value="" name="FNAME" class="" id="mce-FNAME" style="margin:auto;">
+					</div>
+					<div class="mc-field-group">
+						<label for="mce-LNAME">Last Name </label>
+						<input type="text" value="" name="LNAME" class="" id="mce-LNAME" style="margin:auto;">
+					</div>
+					<div class="mc-field-group">
+						<label for="mce-MMERGE5">Business </label>
+						<input type="text" value="" name="MMERGE5" class="" id="mce-MMERGE5" style="margin:auto;">
+					</div>
+					<div id="mce-responses" class="clear">
+						<div class="response" id="mce-error-response" style="display:none"></div>
+						<div class="response" id="mce-success-response" style="display:none"></div>
+					</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+					<div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_df15f7f3ba7071146f98e66b3_6989f14b64" tabindex="-1" value=""></div>
+					<div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+				</div>
+			</form>
+		</div>
+		<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[3]='ADDRESS';ftypes[3]='address';fnames[4]='PHONE';ftypes[4]='phone';fnames[5]='MMERGE5';ftypes[5]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
+		<!--End mc_embed_signup-->
 	</div>
 </div>
 <div class="spacer-15"></div>

--- a/admin/sections/waitlist.php
+++ b/admin/sections/waitlist.php
@@ -17,42 +17,32 @@
     <div class="spacer-10"></div>
     <p>Join the waiting list and you'll be one of the first to get notified when new themes &amp; features are on their way.</p>
     <div class="spacer-10"></div>
-    <?php if ($joined_features_waitlist == false):?>
-        <form id="wmp_waitlist_form" name="wmp_waitlist_form"  method="post">
-            <input name="wmp_waitlist_emailaddress" id="wmp_waitlist_emailaddress" type="text" placeholder="Your e-mail address" class="small" value="<?php echo get_option( 'admin_email' );?>" />
-            <div class="spacer-5"></div>
-            <div class="field-message error" id="error_emailaddress_container"></div>
-            <div class="spacer-10"></div>
-
-            <a class="btn blue smaller" href="javascript:void(0)" id="wmp_waitlist_send_btn">Join waitlist</a>
-        </form>
-    <?php endif;?>
-    <div id="wmp_waitlist_added" class="added" style="display: <?php echo $joined_features_waitlist ? 'block' : 'none'?>;">
-        <div class="switcher blue">
-            <div class="msg">ADDED TO WAITLIST</div>
-            <div class="check"></div>
-        </div>
-        <div class="spacer-15"></div>
-    </div>
-
+    <!-- Begin Mailchimp Signup Form -->
+		<link href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css" rel="stylesheet" type="text/css">
+		<style type="text/css">
+			#mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; }
+			#mc_embed_signup .clear {width:96%;}
+			#mc_embed_signup h2 {width:96%;}
+			/* Add your own Mailchimp form style overrides in your site stylesheet or in this style block.
+				We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
+		</style>
+		<div id="mc_embed_signup">
+			<form action="https://wpmobilepack.us13.list-manage.com/subscribe/post?u=df15f7f3ba7071146f98e66b3&amp;id=6989f14b64" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate style="padding: 0;">
+				<div id="mc_embed_signup_scroll">
+					<div class="mc-field-group">
+						</label>
+						<input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" placeholder="E-mail" style="margin: auto; width: 100%;">
+					</div>
+					<div id="mce-responses" class="clear" style="margin: 0; padding: 0;">
+						<div class="response" id="mce-error-response" style="display:none; margin: 0 0 15px; padding: 0; width: 100%;"></div>
+						<div class="response" id="mce-success-response" style="display:none; margin: 0 0 15px; padding: 0; width: 100%;"></div>
+					</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+					<div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_df15f7f3ba7071146f98e66b3_6989f14b64" tabindex="-1" value=""></div>
+					<div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button btn green smaller"></div>
+				</div>
+			</form>
+		</div>
+		<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[3]='ADDRESS';ftypes[3]='address';fnames[4]='PHONE';ftypes[4]='phone';fnames[5]='MMERGE5';ftypes[5]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
+		<!--End mc_embed_signup-->
 </div>
 <div class="spacer-15"></div>
-
-<script type="text/javascript">
-    if (window.WMPJSInterface && window.WMPJSInterface != null){
-        jQuery(document).ready(function(){
-            <?php if ($joined_features_waitlist == false):?>
-            window.WMPJSInterface.add("UI_joinwaitlist",
-                "WMP_WAITLIST",
-                {
-                    'DOMDoc':       window.document,
-                    'container' :   window.document.getElementById('wmp_waitlist_container'),
-                    'listType' :    'themes_features'
-                },
-                window
-            );
-
-            <?php endif;?>
-        });
-    }
-</script>

--- a/core/config.php
+++ b/core/config.php
@@ -18,9 +18,6 @@ define('WMP_MORE_UPDATES','https://rcksld-wpmp.s3.amazonaws.com/dashboard/more/m
 define('WMP_MORE_UPDATES_HTTPS','https://rcksld-wpmp.s3.amazonaws.com/dashboard/more/more5.json');
 define('WMP_MORE_UPDATES_VERSION', 6);
 
-define('WMP_MAILCHIMP_API_KEY','e661bba1e8d921e2cd7096c2bd677272-us13');
-define('WMP_MAILCHIMP_SUBSCRIBE_LIST_ID','6989f14b64');
-
 define('WMP_APPTICLES_TRACKING_SSL','https://api.wpmobilepack.com/content1/wptracking');
 
 define("WMP_APPTICLES_PRO_LINK", "https://wpmobilepack.com");


### PR DESCRIPTION
## Ticket
https://trello.com/c/kq9WMQyF/47-add-mailchimp-api-endpoint-to-wpmobilepackcom

## Changes Made
* Remove Mailchimp API


## Steps to Test
1. Checkout this branch
2. Go to Dashboard >> WP Mobile Pack >> App Themes and check the subscribe form